### PR TITLE
Indicate invalid form fields in bootstrap mixin

### DIFF
--- a/tapeforms/contrib/bootstrap.py
+++ b/tapeforms/contrib/bootstrap.py
@@ -61,3 +61,18 @@ class BootstrapTapeformMixin(TapeformMixin):
             return 'form-check-input'
 
         return super().get_widget_css_class(field_name, field)
+
+    def add_error(self, field_name, error):
+        """
+        The method is overwritten to append 'is-invalid' to the css class of the
+        field's widget.
+        """
+        super().add_error(field_name, error)
+
+        if field_name in self.fields:
+            field = self.fields[field_name]
+            class_names = field.widget.attrs.get('class', '').split(' ')
+
+            if 'is-invalid' not in class_names:
+                class_names.append('is-invalid')
+                field.widget.attrs['class'] = ' '.join(class_names)

--- a/tapeforms/templates/tapeforms/fields/bootstrap.html
+++ b/tapeforms/templates/tapeforms/fields/bootstrap.html
@@ -20,7 +20,7 @@
 
 {% block errors %}
 	{% for error in errors %}
-		<div class="text-danger small pt-1">{{ error }}</div>
+		<div class="invalid-feedback">{{ error }}</div>
 	{% endfor %}
 {% endblock %}
 

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -43,3 +43,17 @@ class TestBootstrapTapeformMixin:
         form = DummyForm()
         assert form.get_widget_css_class(
             'my_field2', form.fields['my_field2']) == 'form-check-input'
+
+    def test_widget_css_class_invalid(self):
+        form = DummyForm({})
+        form.full_clean()
+        css_classes = form.fields['my_field1'].widget.attrs['class'].split(' ')
+        assert 'is-invalid' in css_classes
+        assert 'form-control' in css_classes
+
+    def test_add_error(self):
+        form = DummyForm({})
+        form.add_error(None, 'Non field error!')
+        form.add_error('my_field1', 'Error!')
+        css_classes = form.fields['my_field1'].widget.attrs['class'].split(' ')
+        assert 'is-invalid' in css_classes


### PR DESCRIPTION
This adds `is-invalid` class to invalid field inputs and uses the dedicated class `invalid-feedback` in its errors - for better customization - as described in [Bootstrap's documentation](https://getbootstrap.com/docs/4.1/components/forms/#server-side).

### Changes
- [x] Use `invalid-feedback` class to the field error instead of custom ones
- [x] Set `is-invalid` class to the field widget when it has error(s)