### PR TITLE
 Add contrib mixin for Foundation

### DIFF
--- a/docs/api_contrib.rst
+++ b/docs/api_contrib.rst
@@ -1,7 +1,18 @@
 Contrib
 =======
 
+Bootstrap mixin
+---------------
+
 .. automodule:: tapeforms.contrib.bootstrap
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Foundation mixin
+----------------
+
+.. automodule:: tapeforms.contrib.foundation
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -16,3 +16,21 @@ have the correct css classes assigned.
 In addition, the mixin uses a different template for the fields because Bootstrap
 requires that the ordering of label and widget inside a field is swapped (widget
 first, label second).
+
+
+Foundation mixin
+----------------
+
+You can use the :py:class:`tapeforms.contrib.foundation.FoundationTapeformMixin`
+to render forms with a Foundation_ compatible HTML layout / css classes.
+
+This alternative mixin makes sure that the rendered widgets, fields and labels
+have the correct CSS classes assigned especially in case of errors.
+
+In addition, the mixin uses a different template for the fields. It is required
+to swap the ordering of label and widget when rendering a checkbox, and also to
+wrap mulitple inputs - e.g. a group of checkboxes or radio buttons - in a
+``fieldset`` element, as `Foundation documentation suggests`__.
+
+.. _Foundation: https://foundation.zurb.com/sites/docs/
+.. __: https://foundation.zurb.com/sites/docs/forms.html#checkboxes-and-radio-buttons

--- a/examples/basic/forms.py
+++ b/examples/basic/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 from tapeforms.mixins import TapeformMixin
 from tapeforms.contrib.bootstrap import BootstrapTapeformMixin
+from tapeforms.contrib.foundation import FoundationTapeformMixin
 
 
 class SimpleForm(TapeformMixin, forms.Form):
@@ -30,6 +31,12 @@ class SimpleWithOverridesForm(TapeformMixin, forms.Form):
 
 
 class SimpleBootstrapForm(BootstrapTapeformMixin, forms.Form):
+    first_name = forms.CharField(label='First name')
+    last_name = forms.CharField(label='Last name', help_text='Some hints')
+    confirm = forms.BooleanField(label='Please confirm')
+
+
+class SimpleFoundationForm(FoundationTapeformMixin, forms.Form):
     first_name = forms.CharField(label='First name')
     last_name = forms.CharField(label='Last name', help_text='Some hints')
     confirm = forms.BooleanField(label='Please confirm')

--- a/examples/basic/forms.py
+++ b/examples/basic/forms.py
@@ -40,6 +40,11 @@ class SimpleFoundationForm(FoundationTapeformMixin, forms.Form):
     first_name = forms.CharField(label='First name')
     last_name = forms.CharField(label='Last name', help_text='Some hints')
     confirm = forms.BooleanField(label='Please confirm')
+    choose_options = forms.MultipleChoiceField(label='Please choose', choices=(
+        ('foo', 'foo'),
+        ('bar', 'bar'),
+        ('baz', 'bar')
+    ), widget=forms.RadioSelect)
 
 
 class SimpleMultiWidgetForm(TapeformMixin, forms.Form):

--- a/examples/basic/templates/basic/foundation_view.html
+++ b/examples/basic/templates/basic/foundation_view.html
@@ -1,0 +1,26 @@
+{% load tapeforms %}
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Simple Foundation</title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.5.0-rc.3/dist/css/foundation.min.css" integrity="sha256-b2khkeAav/7kTh0Bs5h1Xw1kqGL56SziJ5zk6bEvnAw= sha384-7nP0F9FVCI9Qg1SfsjHWQd+4ksCAxlF5pibRyPGxwn7NJpu1XuSaOoMh8JHIDSdk sha512-Rcgo7Zj9clxZoGtt4CBj1aEtCL9gBd64nYl3hkKEuWDwtK7hKY6c4D5vL4njDseuz31u1WWSM42SbvYe/3CZYQ==" crossorigin="anonymous">
+</head>
+
+<body>
+	<div class="grid-container" style="padding:2em">
+		<div class="card">
+			<div class="card-section">
+				<h4>My form</h4>
+				<form action="." method="post" novalidate>
+					{% csrf_token %}
+					{% form form %}
+					<button type="submit" class="button">Submit</button>
+				</form>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/examples/basic/templates/basic/foundation_view.html
+++ b/examples/basic/templates/basic/foundation_view.html
@@ -6,7 +6,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>Simple Foundation</title>
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.5.0-rc.3/dist/css/foundation.min.css" integrity="sha256-b2khkeAav/7kTh0Bs5h1Xw1kqGL56SziJ5zk6bEvnAw= sha384-7nP0F9FVCI9Qg1SfsjHWQd+4ksCAxlF5pibRyPGxwn7NJpu1XuSaOoMh8JHIDSdk sha512-Rcgo7Zj9clxZoGtt4CBj1aEtCL9gBd64nYl3hkKEuWDwtK7hKY6c4D5vL4njDseuz31u1WWSM42SbvYe/3CZYQ==" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.5.0/dist/css/foundation.min.css" integrity="sha256-VEEaOnBKVRoYPn4AID/tY/XKVxKEqXstoo/xZ6nemak= sha384-D46t32f421/hB30qwnim2pIcisNN5GU9+6m2Mfnd3dKpTSFidZLa08/1StEiCFId sha512-WkgzH8VKemDfwrp18r+wgbx+oHXOkfd2kJs7ocAXdGDgonXDXh88E90IRtRZRXtO0IHprxYHYlY14h+wyTsUDA==" crossorigin="anonymous">
 </head>
 
 <body>

--- a/examples/basic/urls.py
+++ b/examples/basic/urls.py
@@ -2,12 +2,14 @@ from django.contrib import admin
 from django.urls import include, path
 
 from .views import (
-    SimpleBootstrapView, SimpleMultiWidgetView, SimpleView, SimpleWithOverridesView)
+    SimpleBootstrapView, SimpleFoundationView, SimpleMultiWidgetView,
+    SimpleView, SimpleWithOverridesView)
 
 
 urlpatterns = [
     path('simple/', SimpleView.as_view()),
     path('overrides/', SimpleWithOverridesView.as_view()),
     path('bootstrap/', SimpleBootstrapView.as_view()),
+    path('foundation/', SimpleFoundationView.as_view()),
     path('multiwidget/', SimpleMultiWidgetView.as_view()),
 ]

--- a/examples/basic/views.py
+++ b/examples/basic/views.py
@@ -1,7 +1,8 @@
 from django.views.generic import FormView
 
 from .forms import (
-    SimpleBootstrapForm, SimpleForm, SimpleMultiWidgetForm, SimpleWithOverridesForm)
+    SimpleBootstrapForm, SimpleFoundationForm, SimpleMultiWidgetForm,
+    SimpleForm, SimpleWithOverridesForm)
 
 
 class SimpleView(FormView):
@@ -17,6 +18,11 @@ class SimpleWithOverridesView(FormView):
 class SimpleBootstrapView(FormView):
     form_class = SimpleBootstrapForm
     template_name = 'basic/bootstrap_view.html'
+
+
+class SimpleFoundationView(FormView):
+    form_class = SimpleFoundationForm
+    template_name = 'basic/foundation_view.html'
 
 
 class SimpleMultiWidgetView(FormView):

--- a/tapeforms/contrib/foundation.py
+++ b/tapeforms/contrib/foundation.py
@@ -47,8 +47,8 @@ class FoundationTapeformMixin(TapeformMixin):
         template_name = super().get_field_template(bound_field, template_name)
 
         if (template_name == self.field_template and
-                bound_field.field.widget.__class__ in (
-                    forms.RadioSelect, forms.CheckboxSelectMultiple)):
+                isinstance(bound_field.field.widget, (
+                    forms.RadioSelect, forms.CheckboxSelectMultiple))):
             return 'tapeforms/fields/foundation_fieldset.html'
 
         return template_name

--- a/tapeforms/contrib/foundation.py
+++ b/tapeforms/contrib/foundation.py
@@ -1,0 +1,48 @@
+from ..mixins import TapeformMixin
+
+
+class FoundationTapeformMixin(TapeformMixin):
+    """
+    Tapeform Mixin to render Foundation compatible forms.
+    (using the template tags provided by `tapeforms`).
+    """
+
+    #: Use a special layout template for Foundation compatible forms.
+    layout_template = 'tapeforms/layouts/foundation.html'
+    #: Use a special field template for Foundation compatible forms.
+    field_template = 'tapeforms/fields/foundation.html'
+    #: Add a special class to invalid field's label.
+    field_label_invalid_css_class = 'is-invalid-label'
+    #: Add a special class to invalid field's widget.
+    widget_invalid_css_class = 'is-invalid-input'
+
+    def get_field_label_css_class(self, bound_field):
+        """
+        Appends 'is-invalid-label' if field has errors.
+        """
+        class_name = super().get_field_label_css_class(bound_field)
+
+        if bound_field.errors:
+            if not class_name:
+                class_name = self.field_label_invalid_css_class
+            else:
+                class_name = '{} {}'.format(
+                    class_name, self.field_label_invalid_css_class)
+
+        return class_name
+
+    def add_error(self, field_name, error):
+        """
+        The method is overwritten to append 'is-invalid-input' to the css class
+        of the field's widget.
+        """
+        super().add_error(field_name, error)
+
+        if field_name in self.fields:
+            widget = self.fields[field_name].widget
+            widget.attrs['aria-invalid'] = 'true'
+
+            class_names = widget.attrs.get('class', '').split(' ')
+            if self.widget_invalid_css_class not in class_names:
+                class_names.append(self.widget_invalid_css_class)
+                widget.attrs['class'] = ' '.join(class_names)

--- a/tapeforms/contrib/foundation.py
+++ b/tapeforms/contrib/foundation.py
@@ -1,3 +1,5 @@
+from django import forms
+
 from ..mixins import TapeformMixin
 
 
@@ -16,6 +18,12 @@ class FoundationTapeformMixin(TapeformMixin):
     #: Add a special class to invalid field's widget.
     widget_invalid_css_class = 'is-invalid-input'
 
+    #: Widgets with multiple inputs require some extra care (don't use ul, etc.)
+    widget_template_overrides = {
+        forms.RadioSelect: 'tapeforms/widgets/foundation_multipleinput.html',
+        forms.CheckboxSelectMultiple: 'tapeforms/widgets/foundation_multipleinput.html'
+    }
+
     def get_field_label_css_class(self, bound_field):
         """
         Appends 'is-invalid-label' if field has errors.
@@ -30,6 +38,20 @@ class FoundationTapeformMixin(TapeformMixin):
                     class_name, self.field_label_invalid_css_class)
 
         return class_name
+
+    def get_field_template(self, bound_field, template_name=None):
+        """
+        Uses a special field template for widget with multiple inputs. It only
+        applies if no other template than the default one has been defined.
+        """
+        template_name = super().get_field_template(bound_field, template_name)
+
+        if (template_name == self.field_template and
+                bound_field.field.widget.__class__ in (
+                    forms.RadioSelect, forms.CheckboxSelectMultiple)):
+            return 'tapeforms/fields/foundation_fieldset.html'
+
+        return template_name
 
     def add_error(self, field_name, error):
         """

--- a/tapeforms/templates/tapeforms/fields/foundation.html
+++ b/tapeforms/templates/tapeforms/fields/foundation.html
@@ -1,0 +1,25 @@
+{% extends 'tapeforms/fields/default.html' %}
+
+
+{% block label %}
+	{% if widget_class_name != 'checkboxinput' %}
+		{# If rendering a checkbox, Foundation requires us to swap ordering of label and input. #}
+		{{ block.super }}
+	{% endif %}
+{% endblock %}
+
+
+{% block widget %}
+    {{ block.super }}
+	{% if widget_class_name == 'checkboxinput' %}
+		{# See label block, we need to render label after input if widget input type is checkbox. #}
+		{% include 'tapeforms/includes/label_tag.html' %}
+	{% endif %}
+{% endblock %}
+
+
+{% block errors %}
+	{% for error in errors %}
+		<span class="form-error is-visible">{{ error }}</span>
+	{% endfor %}
+{% endblock %}

--- a/tapeforms/templates/tapeforms/fields/foundation_fieldset.html
+++ b/tapeforms/templates/tapeforms/fields/foundation_fieldset.html
@@ -1,0 +1,25 @@
+<fieldset class="{{ container_css_class }} {{ container_css_class }}-{{ field_name }} form-widget-{{ widget_class_name }}{% if required %} is-required{% endif %}{% if errors %} has-errors{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+	{% block label %}
+		<legend{% if label_css_class %} class="{{ label_css_class }}"{% endif %}>
+			{{ label }}{% if required %} <span class="required">*</span>{% endif %}
+		</legend>
+	{% endblock %}
+
+	{% block field %}
+		{% block widget %}
+			{{ field }}
+		{% endblock %}
+
+		{% block errors %}
+			{% for error in errors %}
+				<span class="form-error is-visible">{{ error }}</span>
+			{% endfor %}
+		{% endblock %}
+
+		{% block help_text %}
+			{% if help_text %}
+				<p class="help-text">{{ help_text }}</p>
+			{% endif %}
+		{% endblock %}
+	{% endblock %}
+</fieldset>

--- a/tapeforms/templates/tapeforms/layouts/foundation.html
+++ b/tapeforms/templates/tapeforms/layouts/foundation.html
@@ -1,0 +1,8 @@
+{% extends 'tapeforms/layouts/default.html' %}
+
+
+{% block errors %}
+	{% for error in errors %}
+		<div class="callout alert" role="alert">{{ error }}</div>
+	{% endfor %}
+{% endblock %}

--- a/tapeforms/templates/tapeforms/widgets/foundation_multipleinput.html
+++ b/tapeforms/templates/tapeforms/widgets/foundation_multipleinput.html
@@ -1,0 +1,8 @@
+{% for group, options, index in widget.optgroups %}
+	{% for option in options %}
+		<span class="form-widget-inputoption form-widget-inputoption-{{ option.type }}">
+			<input type="{{ option.type }}" name="{{ option.name }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" with widget=option %}>
+			<label{% if option.attrs.id %} for="{{ option.attrs.id }}"{% endif %}>{{ option.label }}</label>
+		</span>
+	{% endfor %}
+{% endfor %}

--- a/tests/contrib/test_foundation.py
+++ b/tests/contrib/test_foundation.py
@@ -1,0 +1,43 @@
+from django import forms
+
+from tapeforms.contrib.foundation import FoundationTapeformMixin
+
+
+class DummyForm(FoundationTapeformMixin, forms.Form):
+    my_field1 = forms.CharField()
+    my_field2 = forms.BooleanField()
+
+
+class DummyFormWithProperties(DummyForm):
+    field_label_css_class = 'custom-label'
+    widget_css_class = 'some-widget-cssclass'
+
+
+class TestFoundationTapeformMixin:
+
+    def test_field_template(self):
+        form = DummyForm()
+        assert form.field_template == 'tapeforms/fields/foundation.html'
+
+    def test_field_label_css_class_default(self):
+        form = DummyForm()
+        assert form.get_field_label_css_class(
+            form['my_field1']) is None
+
+    def test_field_label_css_class_invalid(self):
+        form = DummyForm({})
+        assert form.get_field_label_css_class(
+            form['my_field1']) == 'is-invalid-label'
+
+    def test_field_label_css_class_override_invalid(self):
+        form = DummyFormWithProperties({})
+        assert form.get_field_label_css_class(
+            form['my_field1']) == 'custom-label is-invalid-label'
+
+    def test_add_error(self):
+        form = DummyForm({})
+        form.add_error(None, 'Non field error!')
+        form.add_error('my_field1', 'Error!')
+        widget = form.fields['my_field1'].widget
+        assert widget.attrs['aria-invalid'] == 'true'
+        assert widget.attrs['class'].strip() == 'is-invalid-input'

--- a/tests/contrib/test_foundation.py
+++ b/tests/contrib/test_foundation.py
@@ -6,18 +6,35 @@ from tapeforms.contrib.foundation import FoundationTapeformMixin
 class DummyForm(FoundationTapeformMixin, forms.Form):
     my_field1 = forms.CharField()
     my_field2 = forms.BooleanField()
+    my_field3 = forms.MultipleChoiceField(
+        choices=(('foo', 'foo'), ('bar', 'bar')), widget=forms.RadioSelect)
 
 
 class DummyFormWithProperties(DummyForm):
     field_label_css_class = 'custom-label'
     widget_css_class = 'some-widget-cssclass'
+    field_template = 'form-wide-field-template.html'
 
 
 class TestFoundationTapeformMixin:
 
-    def test_field_template(self):
+    def test_field_template_default(self):
         form = DummyForm()
-        assert form.field_template == 'tapeforms/fields/foundation.html'
+        assert form.get_field_template(
+            form['my_field1']) == 'tapeforms/fields/foundation.html'
+
+    def test_field_template_fieldset(self):
+        form = DummyForm()
+        assert form.get_field_template(
+            form['my_field3']) == 'tapeforms/fields/foundation_fieldset.html'
+        form = DummyFormWithProperties()
+        assert form.get_field_template(
+            form['my_field3']) == 'tapeforms/fields/foundation_fieldset.html'
+
+    def test_field_template_fieldset_override(self):
+        form = DummyForm()
+        assert form.get_field_template(
+            form['my_field3'], 'field-template.html') == 'field-template.html'
 
     def test_field_label_css_class_default(self):
         form = DummyForm()


### PR DESCRIPTION
This adds a new mixin `contrib.foundation.FoundationTapeformMixin` to support [Foundation for Sites](https://foundation.zurb.com/sites/docs/). A special case is made for multiple inputs - they are displayed in a `<fieldset>` - in order to follow the [Form documentation](https://foundation.zurb.com/sites/docs/forms.html#checkboxes-and-radio-buttons).