### PR TITLE
Fix the container of help text in HTML format

### DIFF
--- a/tapeforms/mixins.py
+++ b/tapeforms/mixins.py
@@ -3,7 +3,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
 from . import defaults
-from .utils import join_css_class
+from .utils import is_safe, join_css_class
 
 
 class TapeformLayoutMixin:
@@ -229,6 +229,7 @@ class TapeformMixin(TapeformLayoutMixin):
             'required': bound_field.field.required,
             'label': bound_field.label,
             'label_css_class': self.get_field_label_css_class(bound_field),
+            'help_html': bound_field.help_text if is_safe(bound_field.help_text) else None,
             'help_text': mark_safe(bound_field.help_text) if bound_field.help_text else None,
             'container_css_class': self.get_field_container_css_class(bound_field),
             'widget_class_name': widget_class_name,

--- a/tapeforms/templates/tapeforms/fields/default.html
+++ b/tapeforms/templates/tapeforms/fields/default.html
@@ -13,7 +13,9 @@
 		{% endblock %}
 
 		{% block help_text %}
-			{% if help_text %}
+			{% if help_html %}
+				<div class="help-text">{{ help_html }}</div>
+			{% elif help_text %}
 				<p class="help-text">{{ help_text }}</p>
 			{% endif %}
 		{% endblock %}

--- a/tapeforms/utils.py
+++ b/tapeforms/utils.py
@@ -1,5 +1,14 @@
 from itertools import chain
 
+from django.utils.functional import Promise
+
+
+def is_safe(text):
+    """Checks whether the string is safe."""
+    if isinstance(text, Promise):
+        text = str(text)
+    return hasattr(text, '__html__')
+
 
 def join_css_class(css_class, *additional_css_classes):
     """

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -73,6 +73,7 @@ class TestFormfieldTag:
             'field_id',
             'field_name',
             'form',
+            'help_html',
             'help_text',
             'label',
             'label_css_class',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,14 @@
-from tapeforms.utils import join_css_class
+from django.utils.functional import lazystr
+from django.utils.safestring import mark_safe
+
+from tapeforms.utils import is_safe, join_css_class
+
+
+def test_is_safe():
+    text = '<h1>title</h1>'
+    assert is_safe(text) is False
+    assert is_safe(mark_safe(text)) is True
+    assert is_safe(lazystr(mark_safe(text))) is True
 
 
 class TestJoinCssClass:


### PR DESCRIPTION
Help text of a field can be a list - as for `password1` of `django.contrib.auth.forms.UserCreationForm`. In that case, as it is not phrasing content, it should be contained in something else than `<p>` to be valid and well displayed.

This just checks if the first character of the string is an opening tag to use `<div>` as the container instead. It is not a really strong check as the help text could just be `<b>Some</b> help text`, but I think it could be enough... What do you think?