### PR TITLE
Add 'form-control-file' Bootstrap class for FileInput

### DIFF
--- a/tapeforms/contrib/bootstrap.py
+++ b/tapeforms/contrib/bootstrap.py
@@ -54,12 +54,17 @@ class BootstrapTapeformMixin(TapeformMixin):
 
     def get_widget_css_class(self, field_name, field):
         """
-        Returns 'form-check-input' if widget is CheckboxInput. For all other fields
-        return the default value from the form property ("form-control").
+        Returns 'form-check-input' if widget is CheckboxInput or 'form-control-file'
+        if widget is FileInput. For all other fields return the default value
+        from the form property ("form-control").
         """
         # If we render CheckboxInputs, Bootstrap requires a different
         # widget css class for checkboxes.
         if isinstance(field.widget, forms.CheckboxInput):
             return 'form-check-input'
+
+        # Idem for fileinput.
+        if isinstance(field.widget, forms.FileInput):
+            return 'form-control-file'
 
         return super().get_widget_css_class(field_name, field)

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -6,6 +6,7 @@ from tapeforms.contrib.bootstrap import BootstrapTapeformMixin
 class DummyForm(BootstrapTapeformMixin, forms.Form):
     my_field1 = forms.CharField()
     my_field2 = forms.BooleanField()
+    my_field3 = forms.FileField()
 
 
 class TestBootstrapTapeformMixin:
@@ -43,6 +44,11 @@ class TestBootstrapTapeformMixin:
         form = DummyForm()
         assert form.get_widget_css_class(
             'my_field2', form.fields['my_field2']) == 'form-check-input'
+
+    def test_widget_css_class_fileinput(self):
+        form = DummyForm()
+        assert form.get_widget_css_class(
+            'my_field3', form.fields['my_field3']) == 'form-control-file'
 
     def test_apply_widget_invalid_options(self):
         form = DummyForm({})


### PR DESCRIPTION
This is a little PR about file inputs. 
from https://getbootstrap.com/docs/4.0/components/forms/#form-controls :

> For file inputs, swap the .form-control for .form-control-file