### PR TITLE
Add a mixin for Bulma compatible forms

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,27 +1,21 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
-
 pytest = "*"
 "pytest-pep8" = "*"
 pytest-flakes = "*"
 pytest-isort = "*"
 pytest-django = "*"
+pytest-snapshot = ">=0.4"
 pytest-cov = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
 
-
 [packages]
-
 django = ">=2.0"
 
-
 [requires]
-
 python_version = "3.6"

--- a/docs/api_contrib.rst
+++ b/docs/api_contrib.rst
@@ -9,6 +9,11 @@ Bootstrap mixin
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: tapeforms.contrib.bulma
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Foundation mixin
 ----------------
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -18,6 +18,21 @@ requires that the ordering of label and widget inside a field is swapped (widget
 first, label second).
 
 
+Bulma mixin
+-----------
+
+You can use the :py:class:`tapeforms.contrib.bulma.BulmaTapeformMixin`
+to render forms with a Bulma_ compatible HTML layout / CSS classes.
+
+This alternative mixin makes sure that the rendered widgets, fields and labels
+have the correct CSS classes assigned especially in case of errors.
+
+In addition, the mixin overrides template for several widgets. It also adds
+JavaScript code to retrieve the selected file name of file inputs.
+
+.. _Bulma: https://bulma.io/
+
+
 Foundation mixin
 ----------------
 

--- a/examples/basic/forms.py
+++ b/examples/basic/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 from tapeforms.mixins import TapeformMixin
 from tapeforms.contrib.bootstrap import BootstrapTapeformMixin
+from tapeforms.contrib.bulma import BulmaTapeformMixin
 from tapeforms.contrib.foundation import FoundationTapeformMixin
 
 
@@ -33,6 +34,31 @@ class SimpleWithOverridesForm(TapeformMixin, forms.Form):
 class SimpleBootstrapForm(BootstrapTapeformMixin, forms.Form):
     first_name = forms.CharField(label='First name')
     last_name = forms.CharField(label='Last name', help_text='Some hints')
+    confirm = forms.BooleanField(label='Please confirm')
+
+
+class SimpleBulmaForm(BulmaTapeformMixin, forms.Form):
+    name = forms.CharField(label='Name', help_text='Some hints')
+    email = forms.EmailField(label='Email', required=False)
+    subject = forms.ChoiceField(label='Subject', choices=(
+        ('option1', 'Option 1'),
+        ('option2', 'Option 2'),
+        ('option3', 'Option 3')
+    ))
+    message = forms.CharField(label='Message', widget=forms.Textarea(attrs={
+        'rows': '3'
+    }))
+    attachment = forms.FileField(label='Attachment', required=False)
+    multiple_options = forms.MultipleChoiceField(label='Multiple', choices=(
+        ('option1', 'Option 1'),
+        ('option2', 'Option 2'),
+        ('option3', 'Option 3')
+    ))
+    choose_options = forms.ChoiceField(label='Please choose', choices=(
+        ('foo', 'foo'),
+        ('bar', 'bar'),
+        ('baz', 'bar')
+    ), widget=forms.RadioSelect)
     confirm = forms.BooleanField(label='Please confirm')
 
 

--- a/examples/basic/templates/basic/bulma_view.html
+++ b/examples/basic/templates/basic/bulma_view.html
@@ -5,6 +5,8 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>Simple Bulma</title>
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css" integrity="sha256-qS+snwBgqr+iFVpBB58C9UCxKFhyL03YHpZfdNUhSEw=" crossorigin="anonymous">
+
+		{{ form.media.css }}
 	</head>
 	<body>
 		<section class="section">
@@ -24,5 +26,7 @@
 				</form>
 			</div>
 		</section>
+
+		{{ form.media.js }}
 	</body>
 </html>

--- a/examples/basic/templates/basic/bulma_view.html
+++ b/examples/basic/templates/basic/bulma_view.html
@@ -1,0 +1,28 @@
+{% load tapeforms %}<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>Simple Bulma</title>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css" integrity="sha256-qS+snwBgqr+iFVpBB58C9UCxKFhyL03YHpZfdNUhSEw=" crossorigin="anonymous">
+	</head>
+	<body>
+		<section class="section">
+			<div class="container">
+				<h1 class="title">My form</h1>
+				<form action="." method="post" novalidate>
+					{% csrf_token %}
+					{% form form %}
+					<div class="field is-grouped">
+						<div class="control">
+							<button type="submit" class="button is-link">Submit</button>
+						</div>
+						<div class="control">
+							<button class="button is-link is-light">Cancel</button>
+						</div>
+					</div>
+				</form>
+			</div>
+		</section>
+	</body>
+</html>

--- a/examples/basic/urls.py
+++ b/examples/basic/urls.py
@@ -1,15 +1,19 @@
-from django.contrib import admin
-from django.urls import include, path
+from django.urls import path
 
 from .views import (
-    SimpleBootstrapView, SimpleFoundationView, SimpleMultiWidgetView,
-    SimpleView, SimpleWithOverridesView)
-
+    SimpleBootstrapView,
+    SimpleBulmaView,
+    SimpleFoundationView,
+    SimpleMultiWidgetView,
+    SimpleView,
+    SimpleWithOverridesView,
+)
 
 urlpatterns = [
     path('simple/', SimpleView.as_view()),
     path('overrides/', SimpleWithOverridesView.as_view()),
     path('bootstrap/', SimpleBootstrapView.as_view()),
+    path('bulma/', SimpleBulmaView.as_view()),
     path('foundation/', SimpleFoundationView.as_view()),
     path('multiwidget/', SimpleMultiWidgetView.as_view()),
 ]

--- a/examples/basic/views.py
+++ b/examples/basic/views.py
@@ -1,8 +1,13 @@
 from django.views.generic import FormView
 
 from .forms import (
-    SimpleBootstrapForm, SimpleFoundationForm, SimpleMultiWidgetForm,
-    SimpleForm, SimpleWithOverridesForm)
+    SimpleBootstrapForm,
+    SimpleBulmaForm,
+    SimpleForm,
+    SimpleFoundationForm,
+    SimpleMultiWidgetForm,
+    SimpleWithOverridesForm,
+)
 
 
 class SimpleView(FormView):
@@ -18,6 +23,11 @@ class SimpleWithOverridesView(FormView):
 class SimpleBootstrapView(FormView):
     form_class = SimpleBootstrapForm
     template_name = 'basic/bootstrap_view.html'
+
+
+class SimpleBulmaView(FormView):
+    form_class = SimpleBulmaForm
+    template_name = 'basic/bulma_view.html'
 
 
 class SimpleFoundationView(FormView):

--- a/tapeforms/contrib/bulma.py
+++ b/tapeforms/contrib/bulma.py
@@ -25,6 +25,9 @@ class BulmaTapeformMixin(TapeformMixin):
     widget_css_class = None
     widget_invalid_css_class = 'is-danger'
 
+    class Media:
+        js = ('tapeforms/js/bulma_fileinput.js',)
+
     def get_field_label_css_class(self, bound_field):
         if isinstance(bound_field.field.widget, widgets.CheckboxInput):
             return 'checkbox'

--- a/tapeforms/contrib/bulma.py
+++ b/tapeforms/contrib/bulma.py
@@ -1,0 +1,46 @@
+from django.forms import widgets
+
+from ..mixins import TapeformMixin
+
+
+class BulmaTapeformMixin(TapeformMixin):
+    """
+    Tapeform Mixin to render Bulma compatible forms.
+    (using the template tags provided by `tapeforms`).
+    """
+
+    field_template = 'tapeforms/fields/bulma.html'
+    field_container_css_class = 'field'
+    field_label_css_class = 'label'
+
+    widget_template_overrides = {
+        widgets.FileInput: 'tapeforms/widgets/bulma/file.html',
+        widgets.ClearableFileInput:
+            'tapeforms/widgets/bulma/clearable_file_input.html',
+        widgets.RadioSelect: 'tapeforms/widgets/bulma/radio.html',
+        widgets.Select: 'tapeforms/widgets/bulma/select.html',
+        widgets.SelectMultiple: 'tapeforms/widgets/bulma/select.html',
+        widgets.NullBooleanSelect: 'tapeforms/widgets/bulma/select.html',
+    }
+    widget_css_class = None
+    widget_invalid_css_class = 'is-danger'
+
+    def get_field_label_css_class(self, bound_field):
+        if isinstance(bound_field.field.widget, widgets.CheckboxInput):
+            return 'checkbox'
+
+        return super().get_field_label_css_class(bound_field)
+
+    def get_widget_css_class(self, field_name, field):
+        if isinstance(field.widget, widgets.Textarea):
+            return 'textarea'
+
+        if isinstance(field.widget, widgets.FileInput):
+            return 'file-input'
+
+        if isinstance(field.widget, widgets.Input) and not isinstance(
+            field.widget, widgets.CheckboxInput
+        ):
+            return 'input'
+
+        return super().get_widget_css_class(field_name, field)

--- a/tapeforms/contrib/bulma.py
+++ b/tapeforms/contrib/bulma.py
@@ -9,10 +9,14 @@ class BulmaTapeformMixin(TapeformMixin):
     (using the template tags provided by `tapeforms`).
     """
 
+    #: Use a special field template for Bulma compatible forms.
     field_template = 'tapeforms/fields/bulma.html'
+    #: Bulma requires the "field" class on the field container.
     field_container_css_class = 'field'
+    #: Bulma requires the "label" class on the field label.
     field_label_css_class = 'label'
 
+    #: Override some widget templates for Bulma compatible forms.
     widget_template_overrides = {
         widgets.FileInput: 'tapeforms/widgets/bulma/file.html',
         widgets.ClearableFileInput:
@@ -22,19 +26,29 @@ class BulmaTapeformMixin(TapeformMixin):
         widgets.SelectMultiple: 'tapeforms/widgets/bulma/select.html',
         widgets.NullBooleanSelect: 'tapeforms/widgets/bulma/select.html',
     }
-    widget_css_class = None
+    #: Use a special class to invalid field's widget.
     widget_invalid_css_class = 'is-danger'
 
     class Media:
+        #: Include JavaScript for FileInput widgets.
         js = ('tapeforms/js/bulma_fileinput.js',)
 
     def get_field_label_css_class(self, bound_field):
+        """
+        Returns "checkbox" if widget is CheckboxInput. For all other fields,
+        return the default value from the form property.
+        """
         if isinstance(bound_field.field.widget, widgets.CheckboxInput):
             return 'checkbox'
 
         return super().get_field_label_css_class(bound_field)
 
     def get_widget_css_class(self, field_name, field):
+        """
+        Returns "textarea" if widget is Textarea, "file-input" if it is
+        FileInput or "input" if it is based on Input but not CheckboxInput.
+        For all other fields, return the default value from the form property.
+        """
         if isinstance(field.widget, widgets.Textarea):
             return 'textarea'
 

--- a/tapeforms/static/tapeforms/js/bulma_fileinput.js
+++ b/tapeforms/static/tapeforms/js/bulma_fileinput.js
@@ -1,0 +1,25 @@
+window.addEventListener('DOMContentLoaded', function() {
+	// Iterate over file inputs which don't have yet a placeholder for the
+	// selected file name. It will be created and updated when the value changes.
+	document.querySelectorAll('.control > .file:not(.has-name)')
+		.forEach(function(control) {
+			const label = control.querySelector('label.file-label');
+			const input = control.querySelector('input.file-input');
+
+			const filename = document.createElement('span');
+			filename.className = 'file-name is-hidden';
+			label.appendChild(filename);
+
+			input.onchange = function() {
+				if (!input.files.length) {
+					filename.classList.add('is-hidden');
+					control.classList.remove('has-name');
+				} else {
+					filename.textContent = input.files[0].name;
+
+					filename.classList.remove('is-hidden');
+					control.classList.add('has-name');
+				}
+			}
+		});
+});

--- a/tapeforms/templates/tapeforms/fields/bulma.html
+++ b/tapeforms/templates/tapeforms/fields/bulma.html
@@ -1,0 +1,29 @@
+{% extends 'tapeforms/fields/default.html' %}
+
+{% block label %}
+	{% if widget_class_name != 'checkboxinput' %}
+		{{ block.super }}
+	{% endif %}
+{% endblock %}
+
+{% block widget %}
+	<div class="control">
+		{% if widget_class_name == 'checkboxinput' %}
+			{% include 'tapeforms/includes/label_tag.html' with pre_label=field %}
+		{% else %}
+			{{ field }}
+		{% endif %}
+	</div>
+{% endblock %}
+
+{% block errors %}
+	{% for error in errors %}
+		<div class="help is-danger">{{ error }}</div>
+	{% endfor %}
+{% endblock %}
+
+{% block help_text %}
+	{% if help_text %}
+		<div class="help">{{ help_text }}</div>
+	{% endif %}
+{% endblock %}

--- a/tapeforms/templates/tapeforms/widgets/bulma/clearable_file_input.html
+++ b/tapeforms/templates/tapeforms/widgets/bulma/clearable_file_input.html
@@ -1,0 +1,12 @@
+{% load i18n %}{% include "tapeforms/widgets/bulma/file.html" %}
+{% if widget.is_initial %}
+	<p class="help">
+		{% trans "Currently:" %} <a href="{{ widget.value.url }}">{{ widget.value }}</a>
+		{% if not widget.required %}
+			<label class="checkbox">
+				<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
+				{{ widget.clear_checkbox_label }}
+			</label>
+		{% endif %}
+	</p>
+{% endif %}

--- a/tapeforms/templates/tapeforms/widgets/bulma/file.html
+++ b/tapeforms/templates/tapeforms/widgets/bulma/file.html
@@ -1,0 +1,10 @@
+{% load i18n %}<div class="file">
+	<label class="file-label">
+		{% include "django/forms/widgets/input.html" %}
+		<span class="file-cta">
+			<span class="file-label">
+				{% trans "Choose a file…" %}
+			</span>
+		</span>
+	</label>
+</div>

--- a/tapeforms/templates/tapeforms/widgets/bulma/radio.html
+++ b/tapeforms/templates/tapeforms/widgets/bulma/radio.html
@@ -1,0 +1,8 @@
+{% for group, options, index in widget.optgroups %}
+	{% for option in options %}
+		<label class="radio">
+			<input type="{{ option.type }}" name="{{ option.name }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" with widget=option %}>
+			{{ option.label }}
+		</label>
+	{% endfor %}
+{% endfor %}

--- a/tapeforms/templates/tapeforms/widgets/bulma/select.html
+++ b/tapeforms/templates/tapeforms/widgets/bulma/select.html
@@ -1,0 +1,3 @@
+<div class="select{% if widget.attrs.multiple %} is-multiple{% endif %}">
+	{% include "django/forms/widgets/select.html" %}
+</div>

--- a/tests/contrib/__init__.py
+++ b/tests/contrib/__init__.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from django.template import Context, Template
+from django.test.html import parse_html
+
+
+def prettify_html(element, depth=0):
+    """
+    Turn an HTML element into a nicely formatted string. It is based on
+    `django.test.html.Element.__str__` method and add indentation.
+    """
+    indent = '  ' * depth
+    if isinstance(element, str):
+        return '%s%s' % (indent, element)
+    output = '%s<%s' % (indent, element.name)
+    for key, value in element.attributes:
+        if value:
+            output += ' %s="%s"' % (key, value)
+        else:
+            output += ' %s' % key
+    output += '>'
+    if len(element.children) == 1 and isinstance(element.children[0], str):
+        output += '%s</%s>' % (element.children[0], element.name)
+    elif element.children:
+        depth += 1
+        for child in element.children:
+            output += '\n%s' % (prettify_html(child, depth))
+        output += '\n%s</%s>' % (indent, element.name)
+    return output
+
+
+class FormFieldsSnapshotTestMixin:
+    """
+    Test mixin to validate the snapshot of each field of `form_class`.
+    """
+
+    #: Form class to use when validating fields' snapshots.
+    form_class = None
+
+    #: Directory name inside `base_snapshot_dir` where snapshots are stored.
+    snapshot_dir = None
+
+    base_snapshot_dir = Path('tests', 'snapshots')
+
+    def test_form_field_render(self, field_name, snapshot):
+        output = Template('{% load tapeforms %}{% formfield field %}').render(
+            Context({'field': self.form_class()[field_name]})
+        )
+        snapshot.snapshot_dir = self.base_snapshot_dir / self.snapshot_dir
+        snapshot.assert_match(
+            prettify_html(parse_html(output)), 'field_%s.html' % (field_name)
+        )

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,0 +1,17 @@
+from . import FormFieldsSnapshotTestMixin
+
+
+def pytest_generate_tests(metafunc):
+    # Set the field_name parametrization for the form class defined in
+    # FormFieldsSnapshotTestMixin derived class
+    if issubclass(metafunc.cls, FormFieldsSnapshotTestMixin):
+        if 'field_name' in metafunc.fixturenames:
+            try:
+                fields = metafunc.cls.form_class.declared_fields.keys()
+            except AttributeError:
+                raise ValueError(
+                    "%r must define a valid form_class property" % (
+                        metafunc.cls
+                    )
+                )
+            metafunc.parametrize('field_name', fields)

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -2,57 +2,23 @@ from django import forms
 
 from tapeforms.contrib.bootstrap import BootstrapTapeformMixin
 
+from . import FormFieldsSnapshotTestMixin
+
 
 class DummyForm(BootstrapTapeformMixin, forms.Form):
-    my_field1 = forms.CharField()
-    my_field2 = forms.BooleanField()
-    my_field3 = forms.FileField()
+    text = forms.CharField()
+    checkbox = forms.BooleanField()
+    clearable_file = forms.FileField(required=False)
 
 
-class TestBootstrapTapeformMixin:
-
-    def test_field_template(self):
-        form = DummyForm()
-        assert form.field_template == 'tapeforms/fields/bootstrap.html'
-
-    def test_field_container_css_class_default(self):
-        form = DummyForm()
-        assert form.get_field_container_css_class(
-            form['my_field1']) == 'form-group'
-
-    def test_field_container_css_class_checkbox(self):
-        form = DummyForm()
-        assert form.get_field_container_css_class(
-            form['my_field2']) == 'form-check'
-
-    def test_field_label_css_class_default(self):
-        form = DummyForm()
-        assert form.get_field_label_css_class(
-            form['my_field1']) is None
-
-    def test_field_label_css_class_checkbox(self):
-        form = DummyForm()
-        assert form.get_field_label_css_class(
-            form['my_field2']) == 'form-check-label'
-
-    def test_widget_css_class_default(self):
-        form = DummyForm()
-        assert form.get_widget_css_class(
-            'my_field1', form.fields['my_field1']) == 'form-control'
-
-    def test_widget_css_class_checkbox(self):
-        form = DummyForm()
-        assert form.get_widget_css_class(
-            'my_field2', form.fields['my_field2']) == 'form-check-input'
-
-    def test_widget_css_class_fileinput(self):
-        form = DummyForm()
-        assert form.get_widget_css_class(
-            'my_field3', form.fields['my_field3']) == 'form-control-file'
+class TestBootstrapTapeformMixin(FormFieldsSnapshotTestMixin):
+    form_class = DummyForm
+    snapshot_dir = 'bootstrap'
 
     def test_apply_widget_invalid_options(self):
         form = DummyForm({})
-        assert 'my_field1' in form.errors
-        widget = form.fields['my_field1'].widget
+        assert 'text' in form.errors
+        widget = form.fields['text'].widget
         assert sorted(widget.attrs['class'].split(' ')) == [
-                'form-control', 'is-invalid']
+            'form-control', 'is-invalid'
+        ]

--- a/tests/contrib/test_bulma.py
+++ b/tests/contrib/test_bulma.py
@@ -1,0 +1,22 @@
+from django import forms
+
+from tapeforms.contrib.bulma import BulmaTapeformMixin
+
+from . import FormFieldsSnapshotTestMixin
+
+
+class DummyForm(BulmaTapeformMixin, forms.Form):
+    CHOICES = (('foo', 'Foo'), ('bar', 'Bar'))
+
+    text = forms.CharField()
+    textarea = forms.CharField(widget=forms.Textarea(attrs={'rows': '3'}))
+    checkbox = forms.BooleanField(label='Check me')
+    radios = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
+    select = forms.ChoiceField(choices=CHOICES)
+    select_multiple = forms.MultipleChoiceField(choices=CHOICES)
+    clearable_file = forms.FileField(required=False)
+
+
+class TestBulmaTapeformMixin(FormFieldsSnapshotTestMixin):
+    form_class = DummyForm
+    snapshot_dir = 'bulma'

--- a/tests/contrib/test_bulma.py
+++ b/tests/contrib/test_bulma.py
@@ -20,3 +20,7 @@ class DummyForm(BulmaTapeformMixin, forms.Form):
 class TestBulmaTapeformMixin(FormFieldsSnapshotTestMixin):
     form_class = DummyForm
     snapshot_dir = 'bulma'
+
+    def test_form_media(self):
+        form = DummyForm()
+        assert 'tapeforms/js/bulma_fileinput.js"' in str(form.media)

--- a/tests/contrib/test_foundation.py
+++ b/tests/contrib/test_foundation.py
@@ -2,12 +2,15 @@ from django import forms
 
 from tapeforms.contrib.foundation import FoundationTapeformMixin
 
+from . import FormFieldsSnapshotTestMixin
+
 
 class DummyForm(FoundationTapeformMixin, forms.Form):
-    my_field1 = forms.CharField()
-    my_field2 = forms.BooleanField()
-    my_field3 = forms.MultipleChoiceField(
-        choices=(('foo', 'foo'), ('bar', 'bar')), widget=forms.RadioSelect)
+    text = forms.CharField()
+    checkbox = forms.BooleanField()
+    radios = forms.MultipleChoiceField(
+        choices=(('foo', 'Foo'), ('bar', 'Bar')), widget=forms.RadioSelect
+    )
 
 
 class DummyFormWithProperties(DummyForm):
@@ -16,33 +19,28 @@ class DummyFormWithProperties(DummyForm):
     field_template = 'form-wide-field-template.html'
 
 
-class TestFoundationTapeformMixin:
-
-    def test_field_template_default(self):
-        form = DummyForm()
-        assert form.get_field_template(
-            form['my_field1']) == 'tapeforms/fields/foundation.html'
+class TestFoundationTapeformMixin(FormFieldsSnapshotTestMixin):
+    form_class = DummyForm
+    snapshot_dir = 'foundation'
 
     def test_field_template_fieldset(self):
         form = DummyForm()
         assert form.get_field_template(
-            form['my_field3']) == 'tapeforms/fields/foundation_fieldset.html'
+            form['radios']
+        ) == 'tapeforms/fields/foundation_fieldset.html'
+        assert form.get_field_template(
+            form['radios'], 'field-template.html'
+        ) == 'field-template.html'
         form = DummyFormWithProperties()
         assert form.get_field_template(
-            form['my_field3']) == 'tapeforms/fields/foundation_fieldset.html'
-
-    def test_field_template_fieldset_override(self):
-        form = DummyForm()
-        assert form.get_field_template(
-            form['my_field3'], 'field-template.html') == 'field-template.html'
-
-    def test_field_label_css_class_invalid(self):
-        form = DummyForm({})
-        assert form.get_field_label_css_class(
-            form['my_field1']) == 'is-invalid-label'
+            form['radios']
+        ) == 'tapeforms/fields/foundation_fieldset.html'
 
     def test_apply_widget_invalid_options(self):
         form = DummyForm({})
-        assert 'my_field1' in form.errors
-        widget = form.fields['my_field1'].widget
+        assert 'text' in form.errors
+        assert form.get_field_label_css_class(
+            form['text']
+        ) == 'is-invalid-label'
+        widget = form.fields['text'].widget
         assert widget.attrs['class'] == 'is-invalid-input'

--- a/tests/snapshots/bootstrap/field_checkbox.html
+++ b/tests/snapshots/bootstrap/field_checkbox.html
@@ -1,0 +1,7 @@
+<div class="form-check form-check-checkbox form-widget-checkboxinput is-required">
+  <input class="form-check-input" id="id_checkbox" name="checkbox" required type="checkbox">
+  <label class="form-check-label" for="id_checkbox">
+    Checkbox
+    <span class="required">*</span>
+  </label>
+</div>

--- a/tests/snapshots/bootstrap/field_clearable_file.html
+++ b/tests/snapshots/bootstrap/field_clearable_file.html
@@ -1,0 +1,4 @@
+<div class="form-group form-group-clearable_file form-widget-clearablefileinput">
+  <label for="id_clearable_file">Clearable file</label>
+  <input class="form-control-file" id="id_clearable_file" name="clearable_file" type="file">
+</div>

--- a/tests/snapshots/bootstrap/field_text.html
+++ b/tests/snapshots/bootstrap/field_text.html
@@ -1,0 +1,7 @@
+<div class="form-group form-group-text form-widget-textinput is-required">
+  <label for="id_text">
+    Text
+    <span class="required">*</span>
+  </label>
+  <input class="form-control" id="id_text" name="text" required type="text">
+</div>

--- a/tests/snapshots/bulma/field_checkbox.html
+++ b/tests/snapshots/bulma/field_checkbox.html
@@ -1,0 +1,9 @@
+<div class="field field-checkbox form-widget-checkboxinput is-required">
+  <div class="control">
+    <label class="checkbox" for="id_checkbox">
+      <input id="id_checkbox" name="checkbox" required type="checkbox">
+      Check me
+      <span class="required">*</span>
+    </label>
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_clearable_file.html
+++ b/tests/snapshots/bulma/field_clearable_file.html
@@ -1,0 +1,13 @@
+<div class="field field-clearable_file form-widget-clearablefileinput">
+  <label class="label" for="id_clearable_file">Clearable file</label>
+  <div class="control">
+    <div class="file">
+      <label class="file-label">
+        <input class="file-input" id="id_clearable_file" name="clearable_file" type="file">
+        <span class="file-cta">
+          <span class="file-label">Choose a file…</span>
+        </span>
+      </label>
+    </div>
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_radios.html
+++ b/tests/snapshots/bulma/field_radios.html
@@ -1,0 +1,16 @@
+<div class="field field-radios form-widget-radioselect is-required">
+  <label class="label" for="id_radios_0">
+    Radios
+    <span class="required">*</span>
+  </label>
+  <div class="control">
+    <label class="radio">
+      <input id="id_radios_0" name="radios" required type="radio" value="foo">
+      Foo
+    </label>
+    <label class="radio">
+      <input id="id_radios_1" name="radios" required type="radio" value="bar">
+      Bar
+    </label>
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_select.html
+++ b/tests/snapshots/bulma/field_select.html
@@ -1,0 +1,14 @@
+<div class="field field-select form-widget-select is-required">
+  <label class="label" for="id_select">
+    Select
+    <span class="required">*</span>
+  </label>
+  <div class="control">
+    <div class="select">
+      <select id="id_select" name="select">
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_select_multiple.html
+++ b/tests/snapshots/bulma/field_select_multiple.html
@@ -1,0 +1,14 @@
+<div class="field field-select_multiple form-widget-selectmultiple is-required">
+  <label class="label" for="id_select_multiple">
+    Select multiple
+    <span class="required">*</span>
+  </label>
+  <div class="control">
+    <div class="is-multiple select">
+      <select id="id_select_multiple" multiple name="select_multiple" required>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_text.html
+++ b/tests/snapshots/bulma/field_text.html
@@ -1,0 +1,9 @@
+<div class="field field-text form-widget-textinput is-required">
+  <label class="label" for="id_text">
+    Text
+    <span class="required">*</span>
+  </label>
+  <div class="control">
+    <input class="input" id="id_text" name="text" required type="text">
+  </div>
+</div>

--- a/tests/snapshots/bulma/field_textarea.html
+++ b/tests/snapshots/bulma/field_textarea.html
@@ -1,0 +1,9 @@
+<div class="field field-textarea form-widget-textarea is-required">
+  <label class="label" for="id_textarea">
+    Textarea
+    <span class="required">*</span>
+  </label>
+  <div class="control">
+    <textarea class="textarea" cols="40" id="id_textarea" name="textarea" required rows="3">
+  </div>
+</div>

--- a/tests/snapshots/foundation/field_checkbox.html
+++ b/tests/snapshots/foundation/field_checkbox.html
@@ -1,0 +1,7 @@
+<div class="form-field form-field-checkbox form-widget-checkboxinput is-required">
+  <input id="id_checkbox" name="checkbox" required type="checkbox">
+  <label for="id_checkbox">
+    Checkbox
+    <span class="required">*</span>
+  </label>
+</div>

--- a/tests/snapshots/foundation/field_radios.html
+++ b/tests/snapshots/foundation/field_radios.html
@@ -1,0 +1,14 @@
+<fieldset class="form-field form-field-radios form-widget-radioselect is-required">
+  <legend>
+    Radios
+    <span class="required">*</span>
+  </legend>
+  <span class="form-widget-inputoption form-widget-inputoption-radio">
+    <input id="id_radios_0" name="radios" required type="radio" value="foo">
+    <label for="id_radios_0">Foo</label>
+  </span>
+  <span class="form-widget-inputoption form-widget-inputoption-radio">
+    <input id="id_radios_1" name="radios" required type="radio" value="bar">
+    <label for="id_radios_1">Bar</label>
+  </span>
+</fieldset>

--- a/tests/snapshots/foundation/field_text.html
+++ b/tests/snapshots/foundation/field_text.html
@@ -1,0 +1,7 @@
+<div class="form-field form-field-text form-widget-textinput is-required">
+  <label for="id_text">
+    Text
+    <span class="required">*</span>
+  </label>
+  <input id="id_text" name="text" required type="text">
+</div>


### PR DESCRIPTION
After Bootstrap and Foundation, this adds `tapeforms.contrib.bulma.BulmaTapeformMixin` for rendering forms using [Bulma](https://bulma.io/)! It depends and is based on #11 to ease tests - I can rebase this branch as soon as you approve and merge it.