### PR TITLE
Replace StopIteration and update tested Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 
 python:
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
 
 env:
   - DEPS="Django>=1.11,<1.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   - DEPS="Django>=1.11,<1.12"
-  - DEPS="Django>=2.0,<2.1"
-  - DEPS="Django>=2.1,<2.2"
+  - DEPS="Django>=2.2,<2.3"
+  - DEPS="Django>=3.0,<3.1"
 
 install:
   - pip install pipenv codecov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+* Add support for Python 3.7 and 3.8
+* Remove support for Django 2.0 and 2.1
+
+
 0.2.1 - 2019-02-06
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tapeforms/fieldsets.py
+++ b/tapeforms/fieldsets.py
@@ -147,7 +147,7 @@ class TapeformFieldsetsMixin:
         fieldsets = fieldsets or self.fieldsets
 
         if not fieldsets:
-            raise StopIteration
+            return
 
         # Search for primary marker in at least one of the fieldset kwargs.
         has_primary = any(fieldset.get('primary') for fieldset in fieldsets)


### PR DESCRIPTION
As explained in [PEP 479](https://www.python.org/dev/peps/pep-0479/), new semantic of `StopIteration` has been enabled in Python 3.7. By the way, this updates tested Python and Django versions.