### PR TITLE
Remove form-control css class; add form-check-input at python level; fix #15

### DIFF
--- a/examples/basic/forms.py
+++ b/examples/basic/forms.py
@@ -34,6 +34,11 @@ class SimpleBootstrapForm(BootstrapTapeformMixin, forms.Form):
     first_name = forms.CharField(label='First name')
     last_name = forms.CharField(label='Last name', help_text='Some hints')
     confirm = forms.BooleanField(label='Please confirm')
+    choose_options = forms.MultipleChoiceField(label='Please choose', choices=(
+        ('foo', 'foo'),
+        ('bar', 'bar'),
+        ('baz', 'bar')
+    ), widget=forms.RadioSelect)
 
 
 class SimpleFoundationForm(FoundationTapeformMixin, forms.Form):

--- a/tapeforms/contrib/bootstrap.py
+++ b/tapeforms/contrib/bootstrap.py
@@ -15,7 +15,7 @@ class BootstrapTapeformMixin(TapeformMixin):
     field_template = 'tapeforms/fields/bootstrap.html'
     #: Bootstrap requires that the field has a css class "form-group" applied.
     field_container_css_class = 'form-group'
-    #: All widgets need a css class "form-control" (expect checkboxes).
+    #: All widgets need a css class "form-control" (except checkables and file inputs).
     widget_css_class = 'form-control'
     #: Use a special class to invalid field's widget.
     widget_invalid_css_class = 'is-invalid'
@@ -54,13 +54,17 @@ class BootstrapTapeformMixin(TapeformMixin):
 
     def get_widget_css_class(self, field_name, field):
         """
-        Returns 'form-check-input' if widget is CheckboxInput or 'form-control-file'
-        if widget is FileInput. For all other fields return the default value
-        from the form property ("form-control").
+        Returns 'form-check-input' if input widget is checkable, or
+        'form-control-file' if widget is FileInput. For all other fields
+        return the default value from the form property ("form-control").
         """
-        # If we render CheckboxInputs, Bootstrap requires a different
+        # If we render checkable input widget, Bootstrap requires a different
         # widget css class for checkboxes.
-        if isinstance(field.widget, forms.CheckboxInput):
+        if field.widget.__class__ in [
+            forms.RadioSelect,
+            forms.CheckboxSelectMultiple,
+            forms.CheckboxInput,
+        ]:
             return 'form-check-input'
 
         # Idem for fileinput.

--- a/tapeforms/templates/tapeforms/widgets/bootstrap_multipleinput.html
+++ b/tapeforms/templates/tapeforms/widgets/bootstrap_multipleinput.html
@@ -1,7 +1,7 @@
 {% for group, options, index in widget.optgroups %}
 	{% for option in options %}
 		<div class="form-check">
-			<input type="{{ option.type }}" class="form-check-input" name="{{ option.name }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" with widget=option %}>
+			<input type="{{ option.type }}" name="{{ option.name }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" with widget=option %}>
 			<label class="form-check-label" {% if option.attrs.id %} for="{{ option.attrs.id }}"{% endif %}>{{ option.label }}</label>
 		</div>
 	{% endfor %}

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -9,6 +9,11 @@ class DummyForm(BootstrapTapeformMixin, forms.Form):
     text = forms.CharField()
     checkbox = forms.BooleanField()
     clearable_file = forms.FileField(required=False)
+    radio_buttons = forms.MultipleChoiceField(choices=(
+        ('foo', 'foo'),
+        ('bar', 'bar'),
+        ('baz', 'bar')
+    ), widget=forms.RadioSelect)
 
 
 class TestBootstrapTapeformMixin(FormFieldsSnapshotTestMixin):

--- a/tests/snapshots/bootstrap/field_radio_buttons.html
+++ b/tests/snapshots/bootstrap/field_radio_buttons.html
@@ -1,0 +1,18 @@
+<div class="form-group form-group-radio_buttons form-widget-radioselect is-required">
+  <label for="id_radio_buttons_0">
+    Radio buttons
+    <span class="required">*</span>
+  </label>
+  <div class="form-check">
+    <input class="form-check-input" class="form-control" id="id_radio_buttons_0" name="radio_buttons" required type="radio" value="foo">
+    <label class="form-check-label" for="id_radio_buttons_0">foo</label>
+  </div>
+  <div class="form-check">
+    <input class="form-check-input" class="form-control" id="id_radio_buttons_1" name="radio_buttons" required type="radio" value="bar">
+    <label class="form-check-label" for="id_radio_buttons_1">bar</label>
+  </div>
+  <div class="form-check">
+    <input class="form-check-input" class="form-control" id="id_radio_buttons_2" name="radio_buttons" required type="radio" value="baz">
+    <label class="form-check-label" for="id_radio_buttons_2">bar</label>
+  </div>
+</div>

--- a/tests/snapshots/bootstrap/field_radio_buttons.html
+++ b/tests/snapshots/bootstrap/field_radio_buttons.html
@@ -4,15 +4,15 @@
     <span class="required">*</span>
   </label>
   <div class="form-check">
-    <input class="form-check-input" class="form-control" id="id_radio_buttons_0" name="radio_buttons" required type="radio" value="foo">
+    <input class="form-check-input" id="id_radio_buttons_0" name="radio_buttons" required type="radio" value="foo">
     <label class="form-check-label" for="id_radio_buttons_0">foo</label>
   </div>
   <div class="form-check">
-    <input class="form-check-input" class="form-control" id="id_radio_buttons_1" name="radio_buttons" required type="radio" value="bar">
+    <input class="form-check-input" id="id_radio_buttons_1" name="radio_buttons" required type="radio" value="bar">
     <label class="form-check-label" for="id_radio_buttons_1">bar</label>
   </div>
   <div class="form-check">
-    <input class="form-check-input" class="form-control" id="id_radio_buttons_2" name="radio_buttons" required type="radio" value="baz">
+    <input class="form-check-input" id="id_radio_buttons_2" name="radio_buttons" required type="radio" value="baz">
     <label class="form-check-label" for="id_radio_buttons_2">bar</label>
   </div>
 </div>


### PR DESCRIPTION
I would liked to add html validation but actually it is done by `django.test.html.parse_html`. We will open a bug on this side.