### PR TITLE
Use 'form-field-' as prefix for container CSS class

### DIFF
--- a/tapeforms/templates/tapeforms/fields/default.html
+++ b/tapeforms/templates/tapeforms/fields/default.html
@@ -1,4 +1,4 @@
-<div class="{{ container_css_class }} {{ container_css_class }}-{{ field_name }} form-widget-{{ widget_class_name }}{% if required %} is-required{% endif %}{% if errors %} has-errors{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+<div class="{{ container_css_class }} form-field-{{ field_name }} form-widget-{{ widget_class_name }}{% if required %} is-required{% endif %}{% if errors %} has-errors{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 	{% block label %}
 		{% include 'tapeforms/includes/label_tag.html' %}
 	{% endblock %}

--- a/tapeforms/templates/tapeforms/fields/foundation_fieldset.html
+++ b/tapeforms/templates/tapeforms/fields/foundation_fieldset.html
@@ -1,4 +1,4 @@
-<fieldset class="{{ container_css_class }} {{ container_css_class }}-{{ field_name }} form-widget-{{ widget_class_name }}{% if required %} is-required{% endif %}{% if errors %} has-errors{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+<fieldset class="{{ container_css_class }} form-field-{{ field_name }} form-widget-{{ widget_class_name }}{% if required %} is-required{% endif %}{% if errors %} has-errors{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 	{% block label %}
 		<legend{% if label_css_class %} class="{{ label_css_class }}"{% endif %}>
 			{{ label }}{% if required %} <span class="required">*</span>{% endif %}

--- a/tests/snapshots/bootstrap/field_checkbox.html
+++ b/tests/snapshots/bootstrap/field_checkbox.html
@@ -1,4 +1,4 @@
-<div class="form-check form-check-checkbox form-widget-checkboxinput is-required">
+<div class="form-check form-field-checkbox form-widget-checkboxinput is-required">
   <input class="form-check-input" id="id_checkbox" name="checkbox" required type="checkbox">
   <label class="form-check-label" for="id_checkbox">
     Checkbox

--- a/tests/snapshots/bootstrap/field_clearable_file.html
+++ b/tests/snapshots/bootstrap/field_clearable_file.html
@@ -1,4 +1,4 @@
-<div class="form-group form-group-clearable_file form-widget-clearablefileinput">
+<div class="form-field-clearable_file form-group form-widget-clearablefileinput">
   <label for="id_clearable_file">Clearable file</label>
   <input class="form-control-file" id="id_clearable_file" name="clearable_file" type="file">
 </div>

--- a/tests/snapshots/bootstrap/field_radio_buttons.html
+++ b/tests/snapshots/bootstrap/field_radio_buttons.html
@@ -1,4 +1,4 @@
-<div class="form-group form-group-radio_buttons form-widget-radioselect is-required">
+<div class="form-field-radio_buttons form-group form-widget-radioselect is-required">
   <label for="id_radio_buttons_0">
     Radio buttons
     <span class="required">*</span>

--- a/tests/snapshots/bootstrap/field_text.html
+++ b/tests/snapshots/bootstrap/field_text.html
@@ -1,4 +1,4 @@
-<div class="form-group form-group-text form-widget-textinput is-required">
+<div class="form-field-text form-group form-widget-textinput is-required">
   <label for="id_text">
     Text
     <span class="required">*</span>


### PR DESCRIPTION
Instead of using the value returned by `get_field_container_css_class()` to add a specific CSS class for the field, it uses `form-field-` as prefix. This will fix #7 with a more reliable solution since the prefix will never change - where it could if `container_css_class` changes.