### PR TITLE
Drop support of Django 2.0 and 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ __pycache__/
 *~
 
 .cache
+.coverage
 .pytest_cache
 *.sqlite3

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ and some Django template tags to help you render your forms to HTML.
 Requirements
 ------------
 
-django-tapeforms supports Python 3 only and requires at least Django 2.
+django-tapeforms supports Python 3 only and requires at least Django 2.2.
 No other dependencies are required.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,8 +1,8 @@
 Installation
 ============
 
-django-tapeforms supports Python 3 only and requires at least Django 1.11 (because
-of the template based widget rendering). No other dependencies are required.
+django-tapeforms supports Python 3 only and requires at least Django 2.2.
+No other dependencies are required.
 
 To start, simply install the latest stable package using the command
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = ["LICENSE.rst"]
 python = ">=3.6,<4"
 importlib-metadata = {version = "*", python = "<3.8"}
 
-Django = ">=2"
+Django = ">=2.2"
 Sphinx = {version = ">=3.5", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39}-django{20,21,22,30,31,32}
+envlist = py{36,37,38,39}-django{22,30,31,32}
 
 [gh-actions]
 python =
@@ -12,8 +12,6 @@ python =
 [testenv]
 setenv = PYTHONPATH={toxinidir}
 deps =
-	django20: Django>=2.0,<2.1
-	django21: Django>=2.1,<2.2
 	django22: Django>=2.2,<2.3
 	django30: Django>=3.0,<3.1
 	django31: Django>=3.1,<3.2


### PR DESCRIPTION
As discussed in https://github.com/stephrdev/django-tapeforms/pull/21#issuecomment-893685277.