### PR TITLE
Replace .form-row usage in Bootstrap v5 multiple widgets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 Unreleased
 ----------
 
-* Replace '.form-row' by grid system in Bootstrap v5 multiple widgets
+* Replace removed '.form-row' by grid system in Bootstrap v5 multiple widgets
+* Add '.is-invalid' to multiple widget container in Bootstrap mixins to display
+  the '.invalid-feedback' elements
 
 1.1.0 - 2021-09-13
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Replace '.form-row' by grid system in Bootstrap v5 multiple widgets
+
 1.1.0 - 2021-09-13
 ------------------
 

--- a/tapeforms/contrib/bootstrap.py
+++ b/tapeforms/contrib/bootstrap.py
@@ -81,6 +81,14 @@ class Bootstrap5TapeformMixin(Bootstrap4TapeformMixin):
     #: Almost all labels need a CSS class "form-label".
     field_label_css_class = 'form-label'
 
+    #: Widgets with multiple inputs require some extra care (don't use ul, etc.)
+    widget_template_overrides = {
+        forms.SelectDateWidget: 'tapeforms/widgets/bootstrap5_multiwidget.html',
+        forms.SplitDateTimeWidget: 'tapeforms/widgets/bootstrap5_multiwidget.html',
+        forms.RadioSelect: 'tapeforms/widgets/bootstrap_multipleinput.html',
+        forms.CheckboxSelectMultiple: 'tapeforms/widgets/bootstrap_multipleinput.html',
+    }
+
     def get_widget_css_class(self, field_name, field):
         """
         Returns "form-check-input" if input widget is checkable, or

--- a/tapeforms/templates/tapeforms/widgets/bootstrap5_multiwidget.html
+++ b/tapeforms/templates/tapeforms/widgets/bootstrap5_multiwidget.html
@@ -1,4 +1,4 @@
-<div class="row gx-2">
+<div class="row gx-2{% if 'is-invalid' in widget.attrs.class %} is-invalid{% endif %}">
 	{% for widget in widget.subwidgets %}
 		<div class="col">{% include widget.template_name %}</div>
 	{% endfor %}

--- a/tapeforms/templates/tapeforms/widgets/bootstrap5_multiwidget.html
+++ b/tapeforms/templates/tapeforms/widgets/bootstrap5_multiwidget.html
@@ -1,0 +1,5 @@
+<div class="row gx-2">
+	{% for widget in widget.subwidgets %}
+		<div class="col">{% include widget.template_name %}</div>
+	{% endfor %}
+</div>

--- a/tapeforms/templates/tapeforms/widgets/bootstrap_multiwidget.html
+++ b/tapeforms/templates/tapeforms/widgets/bootstrap_multiwidget.html
@@ -1,4 +1,4 @@
-<div class="form-row">
+<div class="form-row{% if 'is-invalid' in widget.attrs.class %} is-invalid{% endif %}">
 	{% for widget in widget.subwidgets %}
 		<div class="col">{% include widget.template_name %}</div>
 	{% endfor %}

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -43,7 +43,15 @@ class TestBootstrap4TapeformMixin(FormFieldsSnapshotTestMixin):
         widget = form.fields['text'].widget
         assert sorted(widget.attrs['class'].split(' ')) == ['form-control', 'is-invalid']
 
+    def test_invalid_multiwidget_render(self):
+        output = self.render_formfield(self.form_class({})['splitdatetime'])
+        self.assertSnapshotMatch(output, 'field_splitdatetime__invalid.html')
+
 
 class TestBootstrap5TapeformMixin(FormFieldsSnapshotTestMixin):
     form_class = Dummy5Form
     snapshot_dir = 'bootstrap5'
+
+    def test_invalid_multiwidget_render(self):
+        output = self.render_formfield(self.form_class({})['splitdatetime'])
+        self.assertSnapshotMatch(output, 'field_splitdatetime__invalid.html')

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -17,6 +17,7 @@ class DummyBaseForm(forms.Form):
     checkbox = forms.BooleanField()
     clearable_file = forms.FileField(required=False)
     radio_select = forms.MultipleChoiceField(choices=CHOICES, widget=forms.RadioSelect)
+    splitdatetime = forms.SplitDateTimeField()
 
 
 class Dummy4Form(Bootstrap4TapeformMixin, DummyBaseForm):

--- a/tests/snapshots/bootstrap4/field_splitdatetime.html
+++ b/tests/snapshots/bootstrap4/field_splitdatetime.html
@@ -1,0 +1,14 @@
+<div class="form-field-splitdatetime form-group form-widget-splitdatetimewidget is-required">
+  <label for="id_splitdatetime_0">
+    Splitdatetime
+    <span class="required">*</span>
+  </label>
+  <div class="form-row">
+    <div class="col">
+      <input class="form-control" id="id_splitdatetime_0" name="splitdatetime_0" required type="date">
+    </div>
+    <div class="col">
+      <input class="form-control" id="id_splitdatetime_1" name="splitdatetime_1" required type="time">
+    </div>
+  </div>
+</div>

--- a/tests/snapshots/bootstrap4/field_splitdatetime__invalid.html
+++ b/tests/snapshots/bootstrap4/field_splitdatetime__invalid.html
@@ -1,0 +1,15 @@
+<div class="form-field-splitdatetime form-group form-widget-splitdatetimewidget has-errors is-required">
+  <label for="id_splitdatetime_0">
+    Splitdatetime
+    <span class="required">*</span>
+  </label>
+  <div class="form-row is-invalid">
+    <div class="col">
+      <input aria-invalid="true" class="form-control is-invalid" id="id_splitdatetime_0" name="splitdatetime_0" required type="date">
+    </div>
+    <div class="col">
+      <input aria-invalid="true" class="form-control is-invalid" id="id_splitdatetime_1" name="splitdatetime_1" required type="time">
+    </div>
+  </div>
+  <div class="invalid-feedback">This field is required.</div>
+</div>

--- a/tests/snapshots/bootstrap5/field_splitdatetime.html
+++ b/tests/snapshots/bootstrap5/field_splitdatetime.html
@@ -1,0 +1,14 @@
+<div class="form-field-splitdatetime form-widget-splitdatetimewidget is-required mb-3">
+  <label class="form-label" for="id_splitdatetime_0">
+    Splitdatetime
+    <span class="required">*</span>
+  </label>
+  <div class="gx-2 row">
+    <div class="col">
+      <input class="form-control" id="id_splitdatetime_0" name="splitdatetime_0" required type="date">
+    </div>
+    <div class="col">
+      <input class="form-control" id="id_splitdatetime_1" name="splitdatetime_1" required type="time">
+    </div>
+  </div>
+</div>

--- a/tests/snapshots/bootstrap5/field_splitdatetime__invalid.html
+++ b/tests/snapshots/bootstrap5/field_splitdatetime__invalid.html
@@ -1,0 +1,15 @@
+<div class="form-field-splitdatetime form-widget-splitdatetimewidget has-errors is-required mb-3">
+  <label class="form-label" for="id_splitdatetime_0">
+    Splitdatetime
+    <span class="required">*</span>
+  </label>
+  <div class="gx-2 is-invalid row">
+    <div class="col">
+      <input aria-invalid="true" class="form-control is-invalid" id="id_splitdatetime_0" name="splitdatetime_0" required type="date">
+    </div>
+    <div class="col">
+      <input aria-invalid="true" class="form-control is-invalid" id="id_splitdatetime_1" name="splitdatetime_1" required type="time">
+    </div>
+  </div>
+  <div class="invalid-feedback">This field is required.</div>
+</div>


### PR DESCRIPTION
The form-specific layout classes have been dropped from Bootstrap v5 - see https://getbootstrap.com/docs/5.1/migration/#forms. For compatibility I didn't renamed `bootstrap_multiwidget.html` to `bootstrap4_multiwidget.html` which I think would be more coherent…

This also fixes by the way the form field errors display in multiple widgets by adding `.is-invalid` to the widget container.